### PR TITLE
fix archiver dependency

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -15,6 +15,12 @@
 			"revisionTime": "2017-01-04T21:11:26Z"
 		},
 		{
+			"checksumSHA1": "Ov+ja3hmONKxbhq9HAgK/vHSi/0=",
+			"path": "github.com/cyphar/filepath-securejoin",
+			"revision": "90b581977c9ec098414249ecbe5f33b5f83e3f4a",
+			"revisionTime": "2020-11-25T11:45:54Z"
+		},
+		{
 			"checksumSHA1": "hveFTNQ9YEyYRs6SWuXM+XU9qRI=",
 			"path": "github.com/fsnotify/fsnotify",
 			"revision": "fd9ec7deca8bf46ecd2a795baaacf2b3a9be1197",
@@ -175,6 +181,12 @@
 			"path": "github.com/pelletier/go-toml",
 			"revision": "439fbba1f887c286024370cb4f281ba815c4c7d7",
 			"revisionTime": "2016-12-29T18:51:04Z"
+		},
+		{
+			"checksumSHA1": "Qo2E/26skb9mZQ3b2Mh6QDkpBLs=",
+			"path": "github.com/pkg/errors",
+			"revision": "5dd12d0cfe7f152f80558d591504ce685299311e",
+			"revisionTime": "2020-12-14T06:45:52Z"
 		},
 		{
 			"checksumSHA1": "lBehULzb2/kIK3wZ0gz2yNmHq9s=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,16 +3,16 @@
 	"ignore": "test",
 	"package": [
 		{
+			"checksumSHA1": "ErAzenS+fAa2RqBjLw1SFh6da/8=",
+			"path": "code.cloudfoundry.org/archiver/extractor",
+			"revision": "6979f8d756e24eb5dd947057e42e7b7d15bc6a70",
+			"revisionTime": "2021-05-13T17:48:25Z"
+		},
+		{
 			"checksumSHA1": "dPI35hOM4TMrLugm6M1js14jHVQ=",
 			"path": "github.com/asaskevich/govalidator",
 			"revision": "fdf19785fd3558d619ef81212f5edf1d6c2a5911",
 			"revisionTime": "2017-01-04T21:11:26Z"
-		},
-		{
-			"checksumSHA1": "/imsSY/C/Rt5zJO5d9QyrZgG5xo=",
-			"path": "github.com/cloudfoundry/archiver/extractor",
-			"revision": "adbf9ed80351644f326cb1926b9b3c256392254e",
-			"revisionTime": "2016-07-05T18:31:35Z"
 		},
 		{
 			"checksumSHA1": "hveFTNQ9YEyYRs6SWuXM+XU9qRI=",
@@ -219,7 +219,7 @@
 			"revisionTime": "2016-12-13T09:38:49Z"
 		},
 		{
-			"checksumSHA1": "uTQtOqR0ePMMcvuvAIksiIZxhqU=",
+			"checksumSHA1": "Xhsm+TevJogC8U4sG6FO+czBMps=",
 			"path": "golang.org/x/sys/unix",
 			"revision": "d75a52659825e75fff6158388dddc6a5b04f9ba5",
 			"revisionTime": "2016-12-14T18:38:57Z"
@@ -249,13 +249,13 @@
 			"revisionTime": "2016-12-29T11:00:09Z"
 		},
 		{
-			"checksumSHA1": "i14IZXKECObKRUNvTr7xivSL1IU=",
+			"checksumSHA1": "GbXoRDm9HaEn12UP2tqdRQDQlV4=",
 			"path": "golang.org/x/text/unicode/cldr",
 			"revision": "44f4f658a783b0cee41fe0a23b8fc91d9c120558",
 			"revisionTime": "2016-12-29T11:00:09Z"
 		},
 		{
-			"checksumSHA1": "Vircurgvsnt4k26havmxPM67PUA=",
+			"checksumSHA1": "ZKCa+wAQGqlSqljoSFqx9pOOaW8=",
 			"path": "golang.org/x/text/unicode/norm",
 			"revision": "44f4f658a783b0cee41fe0a23b8fc91d9c120558",
 			"revisionTime": "2016-12-29T11:00:09Z"
@@ -267,5 +267,5 @@
 			"revisionTime": "2016-09-28T15:37:09Z"
 		}
 	],
-	"rootPath": "github.com/sgeisbacher/container-juggler"
+	"rootPath": "github.com/Timeular/container-juggler"
 }

--- a/volumeadmin/volume_loader.go
+++ b/volumeadmin/volume_loader.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/cloudfoundry/archiver/extractor"
+	"code.cloudfoundry.org/archiver/extractor"
 	"github.com/spf13/viper"
 )
 


### PR DESCRIPTION
This fixes the path for the cloudfoundry/archiver dependency, which threw an error when building / using `go get`.

We ran into this, because there are no current binaries for the new M1 macs available, which some of our people already have. :sweat_smile: 